### PR TITLE
Adjust Idle Time for multi-core CPUs

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -157,10 +157,13 @@ function systemInfo() {
 
 	$output = shell_exec("grep 'cpu ' /proc/stat | awk '{usage=($2+$4)*100/($2+$4+$5)} END {print usage}'");
 	$cpuusage = round($output, 2); 
+	
+	$output = shell_exec('grep -c processor /proc/cpuinfo');
+	$cpucores = $output;
 
 	$output = shell_exec('cat /proc/uptime');
 	$uptime = format_time(substr($output,0,strpos($output," ")));
-	$idletime = format_time(substr($output,strpos($output," ")));
+	$idletime = format_time((substr($output,strpos($output," ")))/$cpucores);
 
 ?>
 		<h4>System Info:</h4>


### PR DESCRIPTION
Account for multi-core CPUs, such as on the RPi 2 Model B, in the Idle time
calculations.
